### PR TITLE
Fixed error in numToFetch break for follower fetch

### DIFF
--- a/routes/user.go
+++ b/routes/user.go
@@ -1426,7 +1426,7 @@ func (fes *APIServer) getPublicKeyToProfileEntryMapForFollows(publicKeyBytes []b
 		publicKeyToProfileEntry[followPubKeyBase58Check] = followProfileEntry
 
 		// If we've fetched enough followers and we're not fetching all followers, break.
-		if uint64(len(publicKeyToProfileEntry)) > numToFetch && !fetchAllFollows {
+		if uint64(len(publicKeyToProfileEntry)) >= numToFetch && !fetchAllFollows {
 			break
 		}
 	}


### PR DESCRIPTION
Off by one error in getPublicKeyToProfileEntryMapForFollows. This issue is caused by an erroneous clause when checking if number of fetched followers is satisfied.