### PR TITLE
rename WyreBTCAddress to BuyBitCloutBTCAddress to more accurately reflect this flag's purpose

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	WyreAccountId          string
 	WyreApiKey             string
 	WyreSecretKey          string
-	WyreBTCAddress         string
+	BuyBitCloutBTCAddress  string
 	BuyBitCloutSeed        string
 }
 
@@ -113,8 +113,10 @@ func LoadConfig(coreConfig *coreCmd.Config) *Config {
 	config.WyreAccountId = viper.GetString("wyre-account-id")
 	config.WyreApiKey = viper.GetString("wyre-api-key")
 	config.WyreSecretKey = viper.GetString("wyre-secret-key")
-	config.WyreBTCAddress = viper.GetString("wyre-btc-address")
-	// Seed from which BitClout will be sent for orders placed through Wyre
+
+	// BTC address to send all Bitcoin received from Wyre purchases and "Buy With BTC" purchases.
+	config.BuyBitCloutBTCAddress = viper.GetString("buy-bitclout-btc-address")
+	// Seed from which BitClout will be sent for orders placed through Wyre and "Buy With BTC" purchases"
 	config.BuyBitCloutSeed = viper.GetString("buy-bitclout-seed")
 	return &config
 }

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -85,7 +85,7 @@ func (node *Node) Start() {
 		node.Config.WyreAccountId,
 		node.Config.WyreApiKey,
 		node.Config.WyreSecretKey,
-		node.Config.WyreBTCAddress,
+		node.Config.BuyBitCloutBTCAddress,
 		node.Config.BuyBitCloutSeed,
 	)
 	if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -125,8 +125,8 @@ func init() {
 	runCmd.PersistentFlags().String("wyre-url", "", "Wyre API URL")
 	runCmd.PersistentFlags().String("wyre-api-key", "", "Wyre API Key")
 	runCmd.PersistentFlags().String("wyre-secret-key", "", "Wyre Secret Key")
-	runCmd.PersistentFlags().String("wyre-btc-address", "", "BTC Address for all Wyre Wallet Orders")
-	runCmd.PersistentFlags().String("buy-bitclout-seed", "", "Seed phrase from which BitClout will be sent for orders placed through Wyre")
+	runCmd.PersistentFlags().String("buy-bitclout-btc-address", "", "BTC Address for all Wyre Wallet Orders and 'Buy With BTC' purchases")
+	runCmd.PersistentFlags().String("buy-bitclout-seed", "", "Seed phrase from which BitClout will be sent for orders placed through Wyre and 'Buy With BTC' purchases")
 	runCmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
 		viper.BindPFlag(flag.Name, flag)
 	})

--- a/routes/server.go
+++ b/routes/server.go
@@ -213,7 +213,7 @@ type APIServer struct {
 	WyreAccountId string
 	WyreApiKey string
 	WyreSecretKey string
-	WyreBTCAddress string
+	BuyBitCloutBTCAddress string
 	BuyBitCloutSeed string
 
 	// This lock is used when sending seed BitClout to avoid a race condition
@@ -271,7 +271,7 @@ func NewAPIServer(_backendServer *lib.Server,
 	wyreAccountId string,
 	wyreApiKey string,
 	wyreSecretKey string,
-	wyreBTCAddress string,
+	buyBitCloutBTCAddress string,
 	buyBitCloutSeed string,
 ) (*APIServer, error) {
 
@@ -319,7 +319,7 @@ func NewAPIServer(_backendServer *lib.Server,
 		WyreAccountId:                       wyreAccountId,
 		WyreApiKey:                          wyreApiKey,
 		WyreSecretKey:                       wyreSecretKey,
-		WyreBTCAddress:                      wyreBTCAddress,
+		BuyBitCloutBTCAddress:               buyBitCloutBTCAddress,
 		BuyBitCloutSeed:                     buyBitCloutSeed,
 		LastTradeBitCloutPriceHistory:       []LastTradePriceHistoryItem{},
 		// We consider last trade prices from the last hour when determining the current price of BitClout.

--- a/routes/transaction.go
+++ b/routes/transaction.go
@@ -616,7 +616,7 @@ func (fes *APIServer) ExchangeBitcoinStateless(ww http.ResponseWriter, req *http
 		uint64(burnAmountSatoshis),
 		uint64(requestData.FeeRateSatoshisPerKB),
 		pubKey,
-		fes.WyreBTCAddress,
+		fes.BuyBitCloutBTCAddress,
 		fes.Params,
 		utxoSource)
 

--- a/routes/wyre.go
+++ b/routes/wyre.go
@@ -370,7 +370,7 @@ func (fes *APIServer) GetWyreWalletOrderQuotation(ww http.ResponseWriter, req *h
 	// Make and marshal the payload
 	body := WyreWalletOrderQuotationPayload{
 		AccountId: fes.WyreAccountId,
-		Dest: fmt.Sprintf("bitcoin:%v", fes.WyreBTCAddress),
+		Dest: fmt.Sprintf("bitcoin:%v", fes.BuyBitCloutBTCAddress),
 		AmountIncludeFees: true,
 		DestCurrency: "BTC",
 		SourceCurrency: wyreWalletOrderQuotationRequest.SourceCurrency,
@@ -558,7 +558,7 @@ func (fes *APIServer) SetWyreRequestHeaders(req *http.Request, dataBytes []byte)
 }
 
 func (fes *APIServer) GetBTCAddress() string {
-	return fmt.Sprintf("bitcoin:%v", fes.WyreBTCAddress)
+	return fmt.Sprintf("bitcoin:%v", fes.BuyBitCloutBTCAddress)
 }
 
 type GetWyreWalletOrderForPublicKeyRequest struct {


### PR DESCRIPTION
While working on updates to the documentation, I realized that this flag's name was confusing if a node only supports `Buy with BTC`