### PR TITLE
Ln/txn ids only

### DIFF
--- a/routes/exchange.go
+++ b/routes/exchange.go
@@ -423,23 +423,23 @@ type TransactionResponse struct {
 	TransactionIDBase58Check string
 	// The raw hex of the transaction data. This can be fully-constructed from
 	// the human-readable portions of this object.
-	RawTransactionHex string
+	RawTransactionHex string `json:",omitempty"`
 	// The inputs and outputs for this transaction.
-	Inputs  []*InputResponse
-	Outputs []*OutputResponse
+	Inputs  []*InputResponse `json:",omitempty"`
+	Outputs []*OutputResponse `json:",omitempty"`
 	// The signature of the transaction in hex format.
-	SignatureHex string
+	SignatureHex string `json:",omitempty"`
 	// Will always be “0” for basic transfers
-	TransactionType string
+	TransactionType string `json:",omitempty"`
 	// TODO: Create a TransactionMeta portion for the response.
 
 	// The hash of the block in which this transaction was mined. If the
 	// transaction is unconfirmed, this field will be empty. To look up
 	// how many confirmations a transaction has, simply plug this value
 	// into the "block" endpoint.
-	BlockHashHex string
+	BlockHashHex string `json:",omitempty"`
 
-	TransactionMetadata *lib.TransactionMetadata
+	TransactionMetadata *lib.TransactionMetadata `json:",omitempty"`
 }
 
 // TransactionInfoResponse contains information about the transaction

--- a/routes/exchange_test.go
+++ b/routes/exchange_test.go
@@ -1373,8 +1373,9 @@ func TestAPI(t *testing.T) {
 				require.NoError(err, "Problem decoding response")
 			}
 			assert.Equal("", transactionInfoRes.Error)
-			assert.Equal(1, len(transactionInfoRes.TransactionIDs))
-			assert.Equal(lib.PkToString(firstBlockTxn.Hash()[:], apiServer.Params), transactionInfoRes.TransactionIDs[0])
+			assert.Equal(1, len(transactionInfoRes.Transactions))
+			assert.Equal(lib.PkToString(firstBlockTxn.Hash()[:], apiServer.Params),
+				transactionInfoRes.Transactions[0].TransactionIDBase58Check)
 		}
 
 		// Roll back the change we made to the chain.

--- a/routes/exchange_test.go
+++ b/routes/exchange_test.go
@@ -1352,6 +1352,30 @@ func TestAPI(t *testing.T) {
 			assert.Equal(0, len(transactionInfoRes.Transactions[0].Inputs))
 			assert.Equal(1, len(transactionInfoRes.Transactions[0].Outputs))
 		}
+		{
+			// Test IDs only
+			transactionInfoRequest := &APITransactionInfoRequest{
+				PublicKeyBase58Check: senderPkString,
+				IDsOnly: true,
+			}
+			jsonRequest, err := json.Marshal(transactionInfoRequest)
+			require.NoError(err)
+			request, _ := http.NewRequest(
+				"POST", RoutePathAPITransactionInfo, bytes.NewBuffer(jsonRequest))
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			apiServer.router.ServeHTTP(response, request)
+			assert.Equal(200, response.Code, "200 response expected")
+
+			decoder := json.NewDecoder(io.LimitReader(response.Body, MaxRequestBodySizeBytes))
+			transactionInfoRes := APITransactionInfoResponse{}
+			if err := decoder.Decode(&transactionInfoRes); err != nil {
+				require.NoError(err, "Problem decoding response")
+			}
+			assert.Equal("", transactionInfoRes.Error)
+			assert.Equal(1, len(transactionInfoRes.TransactionIDs))
+			assert.Equal(lib.PkToString(firstBlockTxn.Hash()[:], apiServer.Params), transactionInfoRes.TransactionIDs[0])
+		}
 
 		// Roll back the change we made to the chain.
 		apiServer.blockchain.SetBestChain(oldBestChain)


### PR DESCRIPTION
The documentation described for [look up transactions for a public key](https://docs.bitclout.com/devs/exchange-listing-api#look-up-transactions-for-a-public-key) and for the [transaction-info endpoint](https://docs.bitclout.com/devs/exchange-listing-api#api-v-1-transaction-info) explain an `IDsOnly` boolean that can be used to only return the TransactionBase58Check attribute of a transaction.

This resolves @carsenk's issue described [here](https://github.com/bitclout/core/issues/46#issuecomment-868699768)