### PR TITLE
Add shared secret encryption/decryption

### DIFF
--- a/routes/message.go
+++ b/routes/message.go
@@ -299,6 +299,11 @@ func (fes *APIServer) getMessagesStateless(publicKeyBytes []byte,
 			}
 		}
 
+		V2 := false
+		if messageEntry.Version == 2{
+			V2 = true
+		}
+
 		// By now we know this messageEntry is meant to be included in the response.
 		messageEntryRes := &MessageEntryResponse{
 			SenderPublicKeyBase58Check:    lib.PkToString(messageEntry.SenderPublicKey, fes.Params),
@@ -306,7 +311,7 @@ func (fes *APIServer) getMessagesStateless(publicKeyBytes []byte,
 			EncryptedText:                 hex.EncodeToString(messageEntry.EncryptedText),
 			TstampNanos:                   messageEntry.TstampNanos,
 			IsSender:                      !reflect.DeepEqual(messageEntry.RecipientPublicKey, publicKeyBytes),
-			V2:                            messageEntry.V2,
+			V2:                            V2,
 		}
 		contactEntry, _ := contactMap[lib.PkToString(otherPartyPublicKeyBytes, fes.Params)]
 		contactEntry.Messages = append(contactEntry.Messages, messageEntryRes)
@@ -440,6 +445,7 @@ func (fes *APIServer) GetMessagesStateless(ww http.ResponseWriter, rr *http.Requ
 type SendMessageStatelessRequest struct {
 	SenderPublicKeyBase58Check    string `safeForLogging:"true"`
 	RecipientPublicKeyBase58Check string `safeForLogging:"true"`
+	MessageText                   string
 	EncryptedMessageText          string
 	MinFeeRateNanosPerKB          uint64 `safeForLogging:"true"`
 }
@@ -484,7 +490,8 @@ func (fes *APIServer) SendMessageStateless(ww http.ResponseWriter, req *http.Req
 	// Try and create the message for the user.
 	tstamp := uint64(time.Now().UnixNano())
 	txn, totalInput, changeAmount, fees, err := fes.blockchain.CreatePrivateMessageTxn(
-		senderPkBytes, recipientPkBytes, requestData.EncryptedMessageText,
+		senderPkBytes, recipientPkBytes,
+		requestData.MessageText, requestData.EncryptedMessageText,
 		tstamp,
 		requestData.MinFeeRateNanosPerKB, fes.backendServer.GetMempool())
 	if err != nil {

--- a/routes/message.go
+++ b/routes/message.go
@@ -306,6 +306,7 @@ func (fes *APIServer) getMessagesStateless(publicKeyBytes []byte,
 			EncryptedText:                 hex.EncodeToString(messageEntry.EncryptedText),
 			TstampNanos:                   messageEntry.TstampNanos,
 			IsSender:                      !reflect.DeepEqual(messageEntry.RecipientPublicKey, publicKeyBytes),
+			V2:                            messageEntry.V2,
 		}
 		contactEntry, _ := contactMap[lib.PkToString(otherPartyPublicKeyBytes, fes.Params)]
 		contactEntry.Messages = append(contactEntry.Messages, messageEntryRes)
@@ -439,7 +440,7 @@ func (fes *APIServer) GetMessagesStateless(ww http.ResponseWriter, rr *http.Requ
 type SendMessageStatelessRequest struct {
 	SenderPublicKeyBase58Check    string `safeForLogging:"true"`
 	RecipientPublicKeyBase58Check string `safeForLogging:"true"`
-	MessageText                   string
+	EncryptedMessageText          string
 	MinFeeRateNanosPerKB          uint64 `safeForLogging:"true"`
 }
 
@@ -483,7 +484,7 @@ func (fes *APIServer) SendMessageStateless(ww http.ResponseWriter, req *http.Req
 	// Try and create the message for the user.
 	tstamp := uint64(time.Now().UnixNano())
 	txn, totalInput, changeAmount, fees, err := fes.blockchain.CreatePrivateMessageTxn(
-		senderPkBytes, recipientPkBytes, requestData.MessageText,
+		senderPkBytes, recipientPkBytes, requestData.EncryptedMessageText,
 		tstamp,
 		requestData.MinFeeRateNanosPerKB, fes.backendServer.GetMempool())
 	if err != nil {

--- a/routes/shared.go
+++ b/routes/shared.go
@@ -64,6 +64,9 @@ type MessageEntryResponse struct {
 
 	// Whether or not the user is the sender of the message.
 	IsSender bool
+
+	// Indicate if message was encrypted using shared secret
+	V2 bool
 }
 
 type MessageContactResponse struct {


### PR DESCRIPTION
Backend receives EncryptedMessageText (hex) encrypted using shared secret from the frontend. V2 to distinguish between new and legacy encryption schemes.