### PR TITLE
shebang compatible with *nix systems

### DIFF
--- a/scripts/nodes/n0
+++ b/scripts/nodes/n0
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 DATE=`date +%Y%m%d-%H:%M:%S-%N`
 

--- a/scripts/nodes/n0_test
+++ b/scripts/nodes/n0_test
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 DATE=`date +%Y%m%d-%H:%M:%S-%N`
 

--- a/scripts/nodes/n1
+++ b/scripts/nodes/n1
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 DATE=`date +%Y%m%d-%H:%M:%S-%N`
 

--- a/scripts/nodes/n1_test
+++ b/scripts/nodes/n1_test
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 DATE=`date +%Y%m%d-%H:%M:%S-%N`
 

--- a/scripts/nodes/n2
+++ b/scripts/nodes/n2
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 DATE=`date +%Y%m%d-%H:%M:%S-%N`
 

--- a/scripts/nodes/n2_test
+++ b/scripts/nodes/n2_test
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 DATE=`date +%Y%m%d-%H:%M:%S-%N`
 


### PR DESCRIPTION
Currently when I ran these node scripts on my MacOSX system it wasn't able to resolve the shebang `/bin/env`.
```
zsh: ./n0_test: bad interpreter: /bin/env: no such file or directory
```

Reading more I found out that `/usr/bin/env` is more compatible with most `*nix` based systems. This PR is to change it.

For reference - https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html


OS | env path
-- | --
OpenBSD | /usr/bin/env
FreeBSD | /usr/bin/env
Debian | /usr/bin/env
Ubuntu | /usr/bin/env
CentOS | /usr/bin/env
macOS | /usr/bin/env
SUSE | /usr/bin/env
RHEL | /usr/bin/env
NetBSD | /usr/bin/env
Solaris | /usr/bin/env

