### PR TITLE
add default limit to comments

### DIFF
--- a/routes/post.go
+++ b/routes/post.go
@@ -1266,7 +1266,7 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 	})
 
 	commentEntryResponseLength := uint32(len(commentEntryResponseList))
-	// If a user provide a default or -ve limit, default to 10
+	// If a client provides a default(0) or -ve limit, default to 10
 	if requestData.CommentLimit <= 0 {
 		requestData.CommentLimit = 10
 	} 

--- a/routes/post.go
+++ b/routes/post.go
@@ -1266,6 +1266,10 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 	})
 
 	commentEntryResponseLength := uint32(len(commentEntryResponseList))
+	// If a user provide a default or -ve limit, default to 10
+	if requestData.CommentLimit <= 0 {
+		requestData.CommentLimit = 10
+	} 
 	// Slice the comments from the offset up to either the end of the slice or the offset + limit, whichever is smaller.
 	maxIdx := lib.MinUint32(commentEntryResponseLength, requestData.CommentOffset+requestData.CommentLimit)
 	var comments []*PostEntryResponse


### PR DESCRIPTION
As mentioned in https://github.com/bitclout/backend/issues/67 - if a client doesn't provides a default `CommentLimit` to the endpoint, we don't return any comments.  I think the API should be such that if we have 0 or -ve limit provided by client, we should just use some default value (I'm using 10 here).