### PR TITLE
Add IsHodlingPublicKey endpoint

### DIFF
--- a/routes/server.go
+++ b/routes/server.go
@@ -66,6 +66,7 @@ const (
 	RoutePathGetNotifications         = "/api/v0/get-notifications"
 	RoutePathBlockPublicKey           = "/api/v0/block-public-key"
 	RoutePathIsFollowingPublicKey     = "/api/v0/is-following-public-key"
+	RoutePathIsHodlingPublicKey       = "/api/v0/is-hodling-public-key"
 
 	// post.go
 	RoutePathGetPostsStateless       = "/api/v0/get-posts-stateless"
@@ -624,6 +625,13 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			[]string{"POST", "OPTIONS"},
 			RoutePathIsFollowingPublicKey,
 			fes.IsFollowingPublicKey,
+			PublicAccess,
+		},
+		{
+			"IsHodlingPublicKey",
+			[]string{"POST", "OPTIONS"},
+			RoutePathIsHodlingPublicKey,
+			fes.IsHodlingPublicKey,
 			PublicAccess,
 		},
 

--- a/routes/user.go
+++ b/routes/user.go
@@ -2413,3 +2413,81 @@ func (fes *APIServer) IsFollowingPublicKey(ww http.ResponseWriter, req *http.Req
 		return
 	}
 }
+
+type IsHodlingPublicKeyRequest struct {
+	PublicKeyBase58Check            string
+	IsHodlingPublicKeyBase58Check	string
+}
+
+type IsHodlingPublicKeyResponse struct {
+	IsHodling 		bool
+	BalanceEntry 	*BalanceEntryResponse	
+}
+
+func (fes *APIServer) IsHodlingPublicKey(ww http.ResponseWriter, req *http.Request) {
+
+	decoder := json.NewDecoder(io.LimitReader(req.Body, MaxRequestBodySizeBytes))
+	requestData := IsHodlingPublicKeyRequest{}
+	if err := decoder.Decode(&requestData); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf(
+			"IsHodlingPublicKey: Problem parsing request body: %v", err))
+		return
+	}
+
+	var userPublicKeyBytes []byte
+	var err error
+	userPublicKeyBytes, _, err = lib.Base58CheckDecode(requestData.PublicKeyBase58Check)
+	if err != nil || len(userPublicKeyBytes) != btcec.PubKeyBytesLenCompressed {
+		_AddBadRequestError(ww, fmt.Sprintf(
+			"IsHodlingPublicKey: Problem decoding user public key %s: %v",
+			requestData.PublicKeyBase58Check, err))
+		return
+	}
+
+	// Get the public key for the user to check
+	var isHodlingPublicKeyBytes []byte
+	isHodlingPublicKeyBytes, _, err = lib.Base58CheckDecode(requestData.IsHodlingPublicKeyBase58Check)
+	if err != nil || len(isHodlingPublicKeyBytes) != btcec.PubKeyBytesLenCompressed {
+		_AddBadRequestError(ww, fmt.Sprintf(
+			"IsHodlingPublicKey: Problem decoding public key to check %s: %v",
+			requestData.IsHodlingPublicKeyBase58Check, err))
+		return
+	}
+
+	var utxoView *lib.UtxoView
+	utxoView, err = fes.backendServer.GetMempool().GetAugmentedUniversalView()
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("IsHodlingPublicKey: Error getting utxoView: %v", err))
+		return
+	}
+
+	var IsHodling = false
+	var BalanceEntry *BalanceEntryResponse
+
+	pkid := utxoView.GetPKIDForPublicKey(userPublicKeyBytes)
+	youHodlMap, err := fes.GetYouHodlMap(pkid, false, utxoView)
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf(
+			"IsHodlingPublicKey: Could not find HODLers for pub key: %v", requestData.PublicKeyBase58Check))
+		return
+	}
+
+	for _, hodl := range youHodlMap {
+		if hodl.CreatorPublicKeyBase58Check == requestData.IsHodlingPublicKeyBase58Check {
+			BalanceEntry = hodl
+			IsHodling = true
+			break
+		}
+	}
+
+	res := IsHodlingPublicKeyResponse{
+		IsHodling: 		IsHodling,
+		BalanceEntry:	BalanceEntry,
+	}
+
+	if err := json.NewEncoder(ww).Encode(res); err != nil {
+		_AddInternalServerError(ww, fmt.Sprintf("IsHodlingPublicKey: Problem serializing object to JSON: %v", err))
+		return
+	}
+
+}

--- a/routes/user.go
+++ b/routes/user.go
@@ -2464,20 +2464,10 @@ func (fes *APIServer) IsHodlingPublicKey(ww http.ResponseWriter, req *http.Reque
 	var IsHodling = false
 	var BalanceEntry *BalanceEntryResponse
 
-	pkid := utxoView.GetPKIDForPublicKey(userPublicKeyBytes)
-	youHodlMap, err := fes.GetYouHodlMap(pkid, false, utxoView)
-	if err != nil {
-		_AddBadRequestError(ww, fmt.Sprintf(
-			"IsHodlingPublicKey: Could not find HODLers for pub key: %v", requestData.PublicKeyBase58Check))
-		return
-	}
-
-	for _, hodl := range youHodlMap {
-		if hodl.CreatorPublicKeyBase58Check == requestData.IsHodlingPublicKeyBase58Check {
-			BalanceEntry = hodl
-			IsHodling = true
-			break
-		}
+	hodlBalanceEntry, _, _ := utxoView.GetBalanceEntryForHODLerPubKeyAndCreatorPubKey(userPublicKeyBytes, isHodlingPublicKeyBytes)
+	if hodlBalanceEntry != nil {
+		BalanceEntry = _balanceEntryToResponse(hodlBalanceEntry, hodlBalanceEntry.BalanceNanos, nil, fes.Params, utxoView, nil)
+		IsHodling = true
 	}
 
 	res := IsHodlingPublicKeyResponse{

--- a/routes/user.go
+++ b/routes/user.go
@@ -2415,13 +2415,13 @@ func (fes *APIServer) IsFollowingPublicKey(ww http.ResponseWriter, req *http.Req
 }
 
 type IsHodlingPublicKeyRequest struct {
-	PublicKeyBase58Check            string
-	IsHodlingPublicKeyBase58Check	string
+	PublicKeyBase58Check          string
+	IsHodlingPublicKeyBase58Check string
 }
 
 type IsHodlingPublicKeyResponse struct {
-	IsHodling 		bool
-	BalanceEntry 	*BalanceEntryResponse	
+	IsHodling    bool
+	BalanceEntry *BalanceEntryResponse	
 }
 
 func (fes *APIServer) IsHodlingPublicKey(ww http.ResponseWriter, req *http.Request) {
@@ -2481,8 +2481,8 @@ func (fes *APIServer) IsHodlingPublicKey(ww http.ResponseWriter, req *http.Reque
 	}
 
 	res := IsHodlingPublicKeyResponse{
-		IsHodling: 		IsHodling,
-		BalanceEntry:	BalanceEntry,
+		IsHodling:    IsHodling,
+		BalanceEntry: BalanceEntry,
 	}
 
 	if err := json.NewEncoder(ww).Encode(res); err != nil {


### PR DESCRIPTION
Fixes #75 

New endpoint to check if one public key is holding the creator coin of another public key, returns true/flag flag and the BalanceEntry if coin is being held.