### PR TITLE
Fix graceful shutdown of backend node

### DIFF
--- a/cmd/node.go
+++ b/cmd/node.go
@@ -50,7 +50,7 @@ func (node *Node) Start() {
 		twilioClient = twilio.NewClient(node.Config.TwilioAccountSID, node.Config.TwilioAuthToken, nil)
 	}
 
-	apiServer, err := routes.NewAPIServer(
+	node.APIServer, err = routes.NewAPIServer(
 		node.CoreNode.Server,
 		node.CoreNode.Server.GetMempool(),
 		node.CoreNode.Server.GetBlockchain(),
@@ -67,7 +67,7 @@ func (node *Node) Start() {
 		glog.Fatal(err)
 	}
 
-	go apiServer.Start()
+	go node.APIServer.Start()
 }
 
 func (node *Node) Stop() {

--- a/routes/server.go
+++ b/routes/server.go
@@ -249,6 +249,7 @@ func NewAPIServer(
 		// We consider last trade prices from the last hour when determining the current price of BitClout.
 		// This helps prevents attacks that attempt to purchase $CLOUT at below market value.
 		LastTradePriceLookback: uint64(time.Hour.Nanoseconds()),
+		quit:                   make(chan struct{}),
 	}
 
 	fes.StartSeedBalancesMonitoring()


### PR DESCRIPTION
Noticed some segfaults when sending SIGTERM to backend. It appears that the `quit` channel is never created and the `APIServer` pointer on the node data structure was not being set.