### PR TITLE
Z/tutorial creator coins

### DIFF
--- a/routes/admin_tutorial.go
+++ b/routes/admin_tutorial.go
@@ -204,8 +204,6 @@ func (fes *APIServer) AdminGetTutorialCreators(ww http.ResponseWriter, req *http
 		wellKnownPublicKeysBase58Check = append(wellKnownPublicKeysBase58Check, publicKeyBase58Check)
 	}
 
-	fmt.Printf("Here are the undiscovered keys %v", undiscoveredPublicKeysBase58Check)
-
 	res := AdminGetTutorialCreatorResponse{
 		UndiscoveredPublicKeysBase58Check: undiscoveredPublicKeysBase58Check,
 		WellKnownPublicKeysBase58Check: wellKnownPublicKeysBase58Check,

--- a/routes/admin_tutorial.go
+++ b/routes/admin_tutorial.go
@@ -140,8 +140,6 @@ func (fes *APIServer) AdminGetTutorialCreators(ww http.ResponseWriter, req *http
 	undiscoveredSeekKey := _GlobalStateKeyUndiscoveredTutorialCreators
 	maxKeyLen := 1 + btcec.PubKeyBytesLenCompressed
 
-	//returnLimit := 2
-	// TODO: Get all of them, do a randomized sample
 	wellKnownKeys, _, err :=fes.GlobalStateSeek(
 		wellKnownSeekKey,
 		wellKnownSeekKey,

--- a/routes/admin_tutorial.go
+++ b/routes/admin_tutorial.go
@@ -41,7 +41,7 @@ func (fes *APIServer) AdminUpdateTutorialCreator(ww http.ResponseWriter, req *ht
 		} else {
 			tableCreatorIn = "up and coming"
 		}
-		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: cannot add creator to %v, user already exists in %v", tableCreatorIn))
+		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: cannot add creator to %v, user already exists in other index", tableCreatorIn))
 		return
 	}
 
@@ -51,12 +51,10 @@ func (fes *APIServer) AdminUpdateTutorialCreator(ww http.ResponseWriter, req *ht
 		return
 	}
 	var prefix []byte
-	wellKnownPrefix := GlobalStateKeyWellKnownTutorialCreators(pkid.PKID)
-	upAndComingPrefix := GlobalStateKeyUpAndComingTutorialCreators(pkid.PKID)
 	if requestData.IsWellKnown {
-		prefix = wellKnownPrefix
+		prefix = GlobalStateKeyWellKnownTutorialCreators(pkid.PKID)
 	} else {
-		prefix = upAndComingPrefix
+		prefix = GlobalStateKeyUpAndComingTutorialCreators(pkid.PKID)
 	}
 
 	if requestData.IsRemoval {
@@ -83,7 +81,7 @@ func (fes *APIServer) AdminUpdateTutorialCreator(ww http.ResponseWriter, req *ht
 	}
 
 	if err = fes.putUserMetadataInGlobalState(userMetadata); err != nil {
-		_AddBadRequestError(ww, fmt.Sprintf("AdminResetJumioForPublicKey: Problem putting updated user metadata in Global state: %v", err))
+		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: Problem putting updated user metadata in Global state: %v", err))
 		return
 	}
 }

--- a/routes/admin_tutorial.go
+++ b/routes/admin_tutorial.go
@@ -3,8 +3,6 @@ package routes
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/bitclout/core/lib"
-	"github.com/btcsuite/btcd/btcec"
 	"io"
 	"net/http"
 )
@@ -14,17 +12,6 @@ type AdminUpdateTutorialCreatorRequest struct {
 	IsRemoval bool
 	IsWellKnown bool
 	JWT       string
-}
-
-type AdminGetTutorialCreatorsRequest struct {
-	ResponseLimit int
-	JWT       string
-}
-
-
-type AdminGetTutorialCreatorResponse struct {
-	UndiscoveredPublicKeysBase58Check []string
-	WellKnownPublicKeysBase58Check []string
 }
 
 func (fes *APIServer) AdminUpdateTutorialCreator(ww http.ResponseWriter, req *http.Request) {
@@ -47,17 +34,14 @@ func (fes *APIServer) AdminUpdateTutorialCreator(ww http.ResponseWriter, req *ht
 		return
 	}
 
-	if !requestData.IsRemoval && ((userMetadata.IsFeaturedTutorialWellKnownCreator && requestData.IsWellKnown) || (userMetadata.IsFeaturedTutorialUndiscoveredCreator && !requestData.IsWellKnown)) {
-		var currentList string
-		var newList string
-		if requestData.IsWellKnown {
-			newList = "well known creators"
-			currentList = "undiscovered creators"
+	if !requestData.IsRemoval && (userMetadata.IsFeaturedTutorialWellKnownCreator || userMetadata.IsFeaturedTutorialUpAndComingCreator) {
+		var tableCreatorIn string
+		if userMetadata.IsFeaturedTutorialWellKnownCreator {
+			tableCreatorIn = "well known"
 		} else {
-			currentList = "well known creators"
-			newList = "undiscovered creators"
+			tableCreatorIn = "up and coming"
 		}
-		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: cannot add creator to %v, user already exists in %v", newList, currentList))
+		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: cannot add creator to %v, user already exists in %v", tableCreatorIn))
 		return
 	}
 
@@ -68,46 +52,21 @@ func (fes *APIServer) AdminUpdateTutorialCreator(ww http.ResponseWriter, req *ht
 	}
 	var prefix []byte
 	wellKnownPrefix := GlobalStateKeyWellKnownTutorialCreators(pkid.PKID)
-	undiscoveredPrefix := GlobalStateKeyUndiscoveredTutorialCreators(pkid.PKID)
+	upAndComingPrefix := GlobalStateKeyUpAndComingTutorialCreators(pkid.PKID)
 	if requestData.IsWellKnown {
 		prefix = wellKnownPrefix
 	} else {
-		prefix = undiscoveredPrefix
-	}
-
-	// If adding a new creator, make sure they aren't already in the database
-	if (!requestData.IsRemoval) {
-		creatorExistsInWellKnown, err := fes.GlobalStateGet(wellKnownPrefix)
-		if err != nil {
-			_AddBadRequestError(ww, fmt.Sprintf(
-				"AdminUpdateTutorialCreator: Error processing GlobalStateGet: %v", err))
-			return
-		}
-
-	creatorExistsInUndiscovered, err := fes.GlobalStateGet(wellKnownPrefix)
-		if err != nil {
-			_AddBadRequestError(ww, fmt.Sprintf(
-				"AdminUpdateTutorialCreator: Error processing GlobalStateGet: %v", err))
-			return
-		}
-
-		if creatorExistsInWellKnown != nil || creatorExistsInUndiscovered != nil {
-			_AddBadRequestError(ww, fmt.Sprintf(
-				"AdminUpdateTutorialCreator: User already exists in database"))
-			return
-		}
+		prefix = upAndComingPrefix
 	}
 
 	if requestData.IsRemoval {
-		err := fes.GlobalStateDelete(prefix)
-		if err != nil {
+		if err := fes.GlobalStateDelete(prefix); err != nil {
 			_AddBadRequestError(ww, fmt.Sprintf(
 				"AdminUpdateTutorialCreator: Error processing GlobalStateDelete: %v", err))
 			return
 		}
 	} else {
-		err := fes.GlobalStatePut(prefix, []byte{1})
-		if err != nil {
+		if err := fes.GlobalStatePut(prefix, []byte{1}); err != nil {
 			_AddBadRequestError(ww, fmt.Sprintf(
 				"AdminUpdateTutorialCreator: Error processing GlobalStatePut: %v", err))
 			return
@@ -117,97 +76,14 @@ func (fes *APIServer) AdminUpdateTutorialCreator(ww http.ResponseWriter, req *ht
 	// Reset all userMetadata values related to tutorial featured status.
 	if requestData.IsWellKnown {
 		userMetadata.IsFeaturedTutorialWellKnownCreator = !requestData.IsRemoval
-		userMetadata.IsFeaturedTutorialUndiscoveredCreator = false
+		userMetadata.IsFeaturedTutorialUpAndComingCreator = false
 	} else {
-		userMetadata.IsFeaturedTutorialUndiscoveredCreator = !requestData.IsRemoval
+		userMetadata.IsFeaturedTutorialUpAndComingCreator = !requestData.IsRemoval
 		userMetadata.IsFeaturedTutorialWellKnownCreator = false
 	}
 
 	if err = fes.putUserMetadataInGlobalState(userMetadata); err != nil {
 		_AddBadRequestError(ww, fmt.Sprintf("AdminResetJumioForPublicKey: Problem putting updated user metadata in Global state: %v", err))
-		return
-	}
-}
-
-func (fes *APIServer) AdminGetTutorialCreators(ww http.ResponseWriter, req *http.Request) {
-	decoder := json.NewDecoder(io.LimitReader(req.Body, MaxRequestBodySizeBytes))
-	requestData := AdminGetTutorialCreatorsRequest{}
-	if err := decoder.Decode(&requestData); err != nil {
-		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: Problem parsing request body: %v", err))
-		return
-	}
-	wellKnownSeekKey := _GlobalStateKeyWellKnownTutorialCreators
-	undiscoveredSeekKey := _GlobalStateKeyUndiscoveredTutorialCreators
-	maxKeyLen := 1 + btcec.PubKeyBytesLenCompressed
-
-	wellKnownKeys, _, err :=fes.GlobalStateSeek(
-		wellKnownSeekKey,
-		wellKnownSeekKey,
-		maxKeyLen,
-		300,
-		false,
-		false,
-	)
-
-	if err != nil {
-		_AddBadRequestError(ww, fmt.Sprintf(
-			"AdminGetTutorialCreators: Problem seeking through global state keys: #{err}"))
-		return
-	}
-
-	undiscoveredKeys, _, err := fes.GlobalStateSeek(
-		undiscoveredSeekKey,
-		undiscoveredSeekKey,
-		maxKeyLen,
-		300,
-		true,
-		false,
-	)
-
-	if err != nil {
-		_AddBadRequestError(ww, fmt.Sprintf(
-			"AdminGetTutorialCreators: Problem seeking through global state keys: #{err}"))
-		return
-	}
-	var undiscoveredLimit int
-	if len(undiscoveredKeys) < requestData.ResponseLimit {
-		undiscoveredLimit = len(undiscoveredKeys)
-	} else {
-		undiscoveredLimit = requestData.ResponseLimit
-	}
-
-	var undiscoveredPublicKeysBase58Check []string
-	ShuffleKeys(&undiscoveredKeys)
-	for _, dbKeyBytes := range undiscoveredKeys[:undiscoveredLimit] {
-		// Chop the public key out of the db key.
-		// The dbKeyBytes are: [One Prefix Byte][btcec.PubKeyBytesLenCompressed]
-		publicKeyBytes := dbKeyBytes[1 :][:]
-		publicKeyBase58Check := lib.Base58CheckEncode(publicKeyBytes, false, fes.Params)
-		undiscoveredPublicKeysBase58Check = append(undiscoveredPublicKeysBase58Check, publicKeyBase58Check)
-	}
-
-	var wellKnownLimit int
-	if len(wellKnownKeys) < requestData.ResponseLimit {
-		wellKnownLimit = len(wellKnownKeys)
-	} else {
-		wellKnownLimit = requestData.ResponseLimit
-	}
-	var wellKnownPublicKeysBase58Check []string
-	ShuffleKeys(&wellKnownKeys)
-	for _, dbKeyBytes := range wellKnownKeys[:wellKnownLimit] {
-		// Chop the public key out of the db key.
-		// The dbKeyBytes are: [One Prefix Byte][btcec.PubKeyBytesLenCompressed]
-		publicKeyBytes := dbKeyBytes[1 :][:]
-		publicKeyBase58Check := lib.Base58CheckEncode(publicKeyBytes, false, fes.Params)
-		wellKnownPublicKeysBase58Check = append(wellKnownPublicKeysBase58Check, publicKeyBase58Check)
-	}
-
-	res := AdminGetTutorialCreatorResponse{
-		UndiscoveredPublicKeysBase58Check: undiscoveredPublicKeysBase58Check,
-		WellKnownPublicKeysBase58Check: wellKnownPublicKeysBase58Check,
-	}
-	if err = json.NewEncoder(ww).Encode(res); err != nil {
-		_AddBadRequestError(ww, fmt.Sprintf("AdminGetUserMetadata: Problem encoding response as JSON: %v", err))
 		return
 	}
 }

--- a/routes/admin_tutorial.go
+++ b/routes/admin_tutorial.go
@@ -3,15 +3,26 @@ package routes
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/btcsuite/btcd/btcec"
 	"io"
 	"net/http"
 )
 
 type AdminUpdateTutorialCreatorRequest struct {
 	PublicKeyBase58Check string
-	isRemoval bool
-	isWellKnown bool
+	IsRemoval bool
+	IsWellKnown bool
 	JWT       string
+}
+
+type AdminGetTutorialCreatorsRequest struct {
+	JWT       string
+}
+
+
+type AdminGetTutorialCreatorResponse struct {
+	UndiscoveredPublicKeysBase58Check [][]byte
+	WellKnownPublicKeysBase58Check [][]byte
 }
 
 func (fes *APIServer) AdminUpdateTutorialCreator(ww http.ResponseWriter, req *http.Request) {
@@ -34,10 +45,10 @@ func (fes *APIServer) AdminUpdateTutorialCreator(ww http.ResponseWriter, req *ht
 		return
 	}
 
-	if !requestData.isRemoval && ((userMetadata.IsFeaturedTutorialWellKnownCreator && requestData.isWellKnown) || (userMetadata.IsFeaturedTutorialUndiscoveredCreator && !requestData.isWellKnown)) {
+	if !requestData.IsRemoval && ((userMetadata.IsFeaturedTutorialWellKnownCreator && requestData.IsWellKnown) || (userMetadata.IsFeaturedTutorialUndiscoveredCreator && !requestData.IsWellKnown)) {
 		var currentList string
 		var newList string
-		if requestData.isWellKnown {
+		if requestData.IsWellKnown {
 			newList = "well known creators"
 			currentList = "undiscovered creators"
 		} else {
@@ -54,29 +65,123 @@ func (fes *APIServer) AdminUpdateTutorialCreator(ww http.ResponseWriter, req *ht
 		return
 	}
 	var prefix []byte
-	if requestData.isWellKnown {
-		prefix = GlobalStateKeyWellKnownTutorialCreators(pkid.PKID)
+	wellKnownPrefix := GlobalStateKeyWellKnownTutorialCreators(pkid.PKID)
+	undiscoveredPrefix := GlobalStateKeyUndiscoveredTutorialCreators(pkid.PKID)
+	if requestData.IsWellKnown {
+		prefix = wellKnownPrefix
 	} else {
-		prefix = GlobalStateKeyUndiscoveredTutorialCreators(pkid.PKID)
+		prefix = undiscoveredPrefix
 	}
 
-	if requestData.isRemoval {
+	// If adding a new creator, make sure they aren't already in the database
+	if (!requestData.IsRemoval) {
+		creatorExistsInWellKnown, err := fes.GlobalStateGet(wellKnownPrefix)
+		if err != nil {
+			_AddBadRequestError(ww, fmt.Sprintf(
+				"AdminUpdateTutorialCreator: Error processing GlobalStateGet: %v", err))
+			return
+		}
+
+	creatorExistsInUndiscovered, err := fes.GlobalStateGet(wellKnownPrefix)
+		if err != nil {
+			_AddBadRequestError(ww, fmt.Sprintf(
+				"AdminUpdateTutorialCreator: Error processing GlobalStateGet: %v", err))
+			return
+		}
+
+		if creatorExistsInWellKnown != nil || creatorExistsInUndiscovered != nil {
+			_AddBadRequestError(ww, fmt.Sprintf(
+				"AdminUpdateTutorialCreator: User already exists in database"))
+			return
+		}
+	}
+
+	if requestData.IsRemoval {
 		fes.GlobalStateDelete(prefix)
 	} else {
-		fes.GlobalStatePut(prefix, nil)
+		fes.GlobalStatePut(prefix, []byte{1})
 	}
 
 	// Reset all userMetadata values related to tutorial featured status.
-	if requestData.isWellKnown {
-		userMetadata.IsFeaturedTutorialWellKnownCreator = !requestData.isRemoval
+	if requestData.IsWellKnown {
+		userMetadata.IsFeaturedTutorialWellKnownCreator = !requestData.IsRemoval
 		userMetadata.IsFeaturedTutorialUndiscoveredCreator = false
 	} else {
-		userMetadata.IsFeaturedTutorialUndiscoveredCreator = !requestData.isRemoval
+		userMetadata.IsFeaturedTutorialUndiscoveredCreator = !requestData.IsRemoval
 		userMetadata.IsFeaturedTutorialWellKnownCreator = false
 	}
 
 	if err = fes.putUserMetadataInGlobalState(userMetadata); err != nil {
 		_AddBadRequestError(ww, fmt.Sprintf("AdminResetJumioForPublicKey: Problem putting updated user metadata in Global state: %v", err))
+		return
+	}
+}
+
+func (fes *APIServer) AdminGetTutorialCreators(ww http.ResponseWriter, req *http.Request) {
+	decoder := json.NewDecoder(io.LimitReader(req.Body, MaxRequestBodySizeBytes))
+	requestData := AdminGetTutorialCreatorsRequest{}
+	if err := decoder.Decode(&requestData); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: Problem parsing request body: %v", err))
+		return
+	}
+	wellKnownSeekKey := _GlobalStateKeyWellKnownTutorialCreators
+	undiscoveredSeekKey := _GlobalStateKeyWellKnownTutorialCreators
+	maxKeyLen := 1 + btcec.PubKeyBytesLenCompressed
+	// TODO: Get all of them, do a randomized sample
+	wellKnownKeys, _, err :=fes.GlobalStateSeek(
+		wellKnownSeekKey,
+		wellKnownSeekKey,
+		maxKeyLen,
+		5,
+		false,
+		false,
+	)
+
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf(
+			"AdminGetTutorialCreators: Problem seeking through global state keys: #{err}"))
+		return
+	}
+
+	undiscoveredKeys, _, err := fes.GlobalStateSeek(
+		undiscoveredSeekKey,
+		undiscoveredSeekKey,
+		maxKeyLen,
+		5,
+		true,
+		false,
+	)
+
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf(
+			"AdminGetTutorialCreators: Problem seeking through global state keys: #{err}"))
+		return
+	}
+
+	var undiscoveredPublicKeysBase58Check [][]byte
+	for first, dbKeyBytes := range undiscoveredKeys {
+		// Chop the public key out of the db key.
+		// The dbKeyBytes are: [One Prefix Byte][btcec.PubKeyBytesLenCompressed]
+		fmt.Printf("Here are the first, dbkeybytes, and chopped %v | %v | %v", first, dbKeyBytes, dbKeyBytes[1 :][:])
+		undiscoveredPublicKeysBase58Check = append(undiscoveredPublicKeysBase58Check, dbKeyBytes[1 :][:])
+		fmt.Printf("Here is the array %v", undiscoveredPublicKeysBase58Check)
+	}
+
+	var wellKnownPublicKeysBase58Check [][]byte
+	for _, dbKeyBytes := range wellKnownKeys {
+		// Chop the public key out of the db key.
+		// The dbKeyBytes are: [One Prefix Byte][btcec.PubKeyBytesLenCompressed]
+		wellKnownPublicKeysBase58Check = append(wellKnownPublicKeysBase58Check, dbKeyBytes[1 :][:])
+	}
+
+	fmt.Printf("Here are the undiscovered keys %v", undiscoveredPublicKeysBase58Check)
+
+	res := AdminGetTutorialCreatorResponse{
+		UndiscoveredPublicKeysBase58Check: undiscoveredPublicKeysBase58Check,
+		WellKnownPublicKeysBase58Check: wellKnownPublicKeysBase58Check,
+	}
+	if err = json.NewEncoder(ww).Encode(res); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("AdminGetUserMetadata: Problem encoding response as JSON: %v", err))
 		return
 	}
 }

--- a/routes/admin_tutorial.go
+++ b/routes/admin_tutorial.go
@@ -1,0 +1,82 @@
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type AdminUpdateTutorialCreatorRequest struct {
+	PublicKeyBase58Check string
+	isRemoval bool
+	isWellKnown bool
+	JWT       string
+}
+
+func (fes *APIServer) AdminUpdateTutorialCreator(ww http.ResponseWriter, req *http.Request) {
+	decoder := json.NewDecoder(io.LimitReader(req.Body, MaxRequestBodySizeBytes))
+	requestData := AdminUpdateTutorialCreatorRequest{}
+	if err := decoder.Decode(&requestData); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: Problem parsing request body: %v", err))
+		return
+	}
+	utxoView, err := fes.backendServer.GetMempool().GetAugmentedUniversalView()
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: error getting utxoview: %v", err))
+		return
+	}
+
+	var userMetadata *UserMetadata
+	userMetadata, err = fes.getUserMetadataFromGlobalState(requestData.PublicKeyBase58Check)
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: error getting usermetadata for public key: %v", err))
+		return
+	}
+
+	if !requestData.isRemoval && ((userMetadata.IsFeaturedTutorialWellKnownCreator && requestData.isWellKnown) || (userMetadata.IsFeaturedTutorialUndiscoveredCreator && !requestData.isWellKnown)) {
+		var currentList string
+		var newList string
+		if requestData.isWellKnown {
+			newList = "well known creators"
+			currentList = "undiscovered creators"
+		} else {
+			currentList = "well known creators"
+			newList = "undiscovered creators"
+		}
+		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: cannot add creator to %v, user already exists in %v", newList, currentList))
+		return
+	}
+
+	pkid := utxoView.GetPKIDForPublicKey(userMetadata.PublicKey)
+	if pkid == nil {
+		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: No PKID found for public key: %v", requestData.PublicKeyBase58Check))
+		return
+	}
+	var prefix []byte
+	if requestData.isWellKnown {
+		prefix = GlobalStateKeyWellKnownTutorialCreators(pkid.PKID)
+	} else {
+		prefix = GlobalStateKeyUndiscoveredTutorialCreators(pkid.PKID)
+	}
+
+	if requestData.isRemoval {
+		fes.GlobalStateDelete(prefix)
+	} else {
+		fes.GlobalStatePut(prefix, nil)
+	}
+
+	// Reset all userMetadata values related to tutorial featured status.
+	if requestData.isWellKnown {
+		userMetadata.IsFeaturedTutorialWellKnownCreator = !requestData.isRemoval
+		userMetadata.IsFeaturedTutorialUndiscoveredCreator = false
+	} else {
+		userMetadata.IsFeaturedTutorialUndiscoveredCreator = !requestData.isRemoval
+		userMetadata.IsFeaturedTutorialWellKnownCreator = false
+	}
+
+	if err = fes.putUserMetadataInGlobalState(userMetadata); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("AdminResetJumioForPublicKey: Problem putting updated user metadata in Global state: %v", err))
+		return
+	}
+}

--- a/routes/global_state.go
+++ b/routes/global_state.go
@@ -150,6 +150,12 @@ var (
 	// Jumio BitCloutNanos
 	_GlobalStatePrefixJumioBitCloutNanos = []byte{21}
 
+	// Tutorial featured well-known creators
+	_GlobalStateKeyWellKnownTutorialCreators = []byte{22}
+
+	// Tutorial featured undiscovered creators
+	_GlobalStateKeyUndiscoveredTutorialCreators = []byte{23}
+
 	// TODO: This process is a bit error-prone. We should come up with a test or
 	// something to at least catch cases where people have two prefixes with the
 	// same ID.
@@ -251,6 +257,12 @@ type UserMetadata struct {
 	// HasPurchasedCreatorCoin = set to true if user has purchased a creator coin, allows them to perform basic transfer
 	// after getting free CLOUT.
 	HasPurchasedCreatorCoin bool
+
+	// If user is featured as a well known creator in the tutorial.
+	IsFeaturedTutorialWellKnownCreator bool
+	// If user is featured as an undiscovered creator in the tutorial.
+	// Note: a user should not be both featured as well known and undiscovered
+	IsFeaturedTutorialUndiscoveredCreator bool
 }
 
 // This struct contains all the metadata associated with a user's phone number.
@@ -441,6 +453,18 @@ func GlobalStateKeyForCountryIDDocumentTypeSubTypeDocumentNumber(countryID strin
 func GlobalStateKeyForJumioBitCloutNanos() []byte {
 	prefixCopy := append([]byte{}, _GlobalStatePrefixJumioBitCloutNanos...)
 	return prefixCopy
+}
+
+func GlobalStateKeyWellKnownTutorialCreators(pkid *lib.PKID) []byte {
+	prefixCopy := append([]byte{}, _GlobalStateKeyWellKnownTutorialCreators...)
+	key := append(prefixCopy, pkid[:]...)
+	return key
+}
+
+func GlobalStateKeyUndiscoveredTutorialCreators(pkid *lib.PKID) []byte {
+	prefixCopy := append([]byte{}, _GlobalStateKeyUndiscoveredTutorialCreators...)
+	key := append(prefixCopy, pkid[:]...)
+	return key
 }
 
 type GlobalStatePutRemoteRequest struct {

--- a/routes/global_state.go
+++ b/routes/global_state.go
@@ -265,7 +265,7 @@ type UserMetadata struct {
 	// Note: a user should not be both featured as well known and up and coming
 	IsFeaturedTutorialUpAndComingCreator bool
 
-  TutorialStatus TutorialStatus
+	TutorialStatus TutorialStatus
 	CreatorPurchasedInTutorialPKID *lib.PKID
 }
 

--- a/routes/global_state.go
+++ b/routes/global_state.go
@@ -153,8 +153,8 @@ var (
 	// Tutorial featured well-known creators
 	_GlobalStateKeyWellKnownTutorialCreators = []byte{22}
 
-	// Tutorial featured undiscovered creators
-	_GlobalStateKeyUndiscoveredTutorialCreators = []byte{23}
+	// Tutorial featured up and coming creators
+	_GlobalStateKeyUpAndComingTutorialCreators = []byte{23}
 
 	// TODO: This process is a bit error-prone. We should come up with a test or
 	// something to at least catch cases where people have two prefixes with the
@@ -260,9 +260,9 @@ type UserMetadata struct {
 
 	// If user is featured as a well known creator in the tutorial.
 	IsFeaturedTutorialWellKnownCreator bool
-	// If user is featured as an undiscovered creator in the tutorial.
-	// Note: a user should not be both featured as well known and undiscovered
-	IsFeaturedTutorialUndiscoveredCreator bool
+	// If user is featured as an up and coming creator in the tutorial.
+	// Note: a user should not be both featured as well known and up and coming
+	IsFeaturedTutorialUpAndComingCreator bool
 }
 
 // This struct contains all the metadata associated with a user's phone number.
@@ -461,8 +461,8 @@ func GlobalStateKeyWellKnownTutorialCreators(pkid *lib.PKID) []byte {
 	return key
 }
 
-func GlobalStateKeyUndiscoveredTutorialCreators(pkid *lib.PKID) []byte {
-	prefixCopy := append([]byte{}, _GlobalStateKeyUndiscoveredTutorialCreators...)
+func GlobalStateKeyUpAndComingTutorialCreators(pkid *lib.PKID) []byte {
+	prefixCopy := append([]byte{}, _GlobalStateKeyUpAndComingTutorialCreators...)
 	key := append(prefixCopy, pkid[:]...)
 	return key
 }

--- a/routes/server.go
+++ b/routes/server.go
@@ -112,6 +112,9 @@ const (
 	RoutePathJumioFlowFinished                 = "/api/v0/jumio-flow-finished"
 	RoutePathGetJumioStatusForPublicKey        = "/api/v0/get-jumio-status-for-public-key"
 
+	// tutorial.go
+	RoutePathGetTutorialCreators         = "/api/v0/get-tutorial-creators"
+
 	// wyre.go
 	RoutePathGetWyreWalletOrderQuotation     = "/api/v0/get-wyre-wallet-order-quotation"
 	RoutePathGetWyreWalletOrderReservation   = "/api/v0/get-wyre-wallet-order-reservation"
@@ -168,7 +171,6 @@ const (
 
 	// admin_tutorial.go
 	RoutePathAdminUpdateTutorialCreators = "/api/v0/admin/update-tutorial-creators"
-	RoutePathAdminGetTutorialCreators = "/api/v0/admin/get-tutorial-creators"
 )
 
 // APIServer provides the interface between the blockchain and things like the
@@ -696,6 +698,14 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			fes.GetJumioStatusForPublicKey,
 			PublicAccess,
 		},
+		// Tutorial Routes
+		{
+			"GetTutorialCreators",
+			[]string{"POST", "OPTIONS"},
+			RoutePathGetTutorialCreators,
+			fes.GetTutorialCreators,
+			PublicAccess,
+		},
 		// Begin all /admin routes
 		{
 			// Route for all low-level node operations.
@@ -873,13 +883,6 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			[]string{"POST", "OPTIONS"},
 			RoutePathAdminUpdateTutorialCreators,
 			fes.AdminUpdateTutorialCreator,
-			SuperAdminAccess,
-		},
-		{
-			"AdminGetTutorialCreators",
-			[]string{"POST", "OPTIONS"},
-			RoutePathAdminGetTutorialCreators,
-			fes.AdminGetTutorialCreators,
 			SuperAdminAccess,
 		},
 		// End all /admin routes

--- a/routes/server.go
+++ b/routes/server.go
@@ -168,6 +168,7 @@ const (
 
 	// admin_tutorial.go
 	RoutePathAdminUpdateTutorialCreators = "/api/v0/admin/update-tutorial-creators"
+	RoutePathAdminGetTutorialCreators = "/api/v0/admin/get-tutorial-creators"
 )
 
 // APIServer provides the interface between the blockchain and things like the
@@ -872,6 +873,13 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			[]string{"POST", "OPTIONS"},
 			RoutePathAdminUpdateTutorialCreators,
 			fes.AdminUpdateTutorialCreator,
+			SuperAdminAccess,
+		},
+		{
+			"AdminGetTutorialCreators",
+			[]string{"POST", "OPTIONS"},
+			RoutePathAdminGetTutorialCreators,
+			fes.AdminGetTutorialCreators,
 			SuperAdminAccess,
 		},
 		// End all /admin routes

--- a/routes/server.go
+++ b/routes/server.go
@@ -80,16 +80,16 @@ const (
 	RoutePathGetDiamondedPosts       = "/api/v0/get-diamonded-posts"
 
 	// nft.go
-	RoutePathCreateNFT               = "/api/v0/create-nft"
-	RoutePathUpdateNFT               = "/api/v0/update-nft"
-	RoutePathGetNFTsForUser          = "/api/v0/get-nfts-for-user"
-	RoutePathGetNFTBidsForUser       = "/api/v0/get-nft-bids-for-user"
-	RoutePathCreateNFTBid            = "/api/v0/create-nft-bid"
-	RoutePathAcceptNFTBid            = "/api/v0/accept-nft-bid"
-	RoutePathGetNFTBidsForNFTPost    = "/api/v0/get-nft-bids-for-nft-post"
-	RoutePathGetNFTShowcase          = "/api/v0/get-nft-showcase"
-	RoutePathGetNextNFTShowcase      = "/api/v0/get-next-nft-showcase"
-	RoutePathGetNFTCollectionSummary = "/api/v0/get-nft-collection-summary"
+	RoutePathCreateNFT                = "/api/v0/create-nft"
+	RoutePathUpdateNFT                = "/api/v0/update-nft"
+	RoutePathGetNFTsForUser           = "/api/v0/get-nfts-for-user"
+	RoutePathGetNFTBidsForUser        = "/api/v0/get-nft-bids-for-user"
+	RoutePathCreateNFTBid             = "/api/v0/create-nft-bid"
+	RoutePathAcceptNFTBid             = "/api/v0/accept-nft-bid"
+	RoutePathGetNFTBidsForNFTPost     = "/api/v0/get-nft-bids-for-nft-post"
+	RoutePathGetNFTShowcase           = "/api/v0/get-nft-showcase"
+	RoutePathGetNextNFTShowcase       = "/api/v0/get-next-nft-showcase"
+	RoutePathGetNFTCollectionSummary  = "/api/v0/get-nft-collection-summary"
 	RoutePathGetNFTEntriesForPostHash = "/api/v0/get-nft-entries-for-nft-post"
 
 	// media.go
@@ -162,10 +162,12 @@ const (
 	RoutePathAdminGetNFTDrop    = "/api/v0/admin/get-nft-drop"
 	RoutePathAdminUpdateNFTDrop = "/api/v0/admin/update-nft-drop"
 
-
 	// admin_jumio.go
-	RoutePathAdminResetJumioForPublicKey       = "/api/v0/admin/reset-jumio-for-public-key"
-	RoutePathAdminUpdateJumioBitClout          = "/api/v0/admin/update-jumio-bitclout"
+	RoutePathAdminResetJumioForPublicKey = "/api/v0/admin/reset-jumio-for-public-key"
+	RoutePathAdminUpdateJumioBitClout    = "/api/v0/admin/update-jumio-bitclout"
+
+	// admin_tutorial.go
+	RoutePathAdminUpdateTutorialCreators = "/api/v0/admin/update-tutorial-creators"
 )
 
 // APIServer provides the interface between the blockchain and things like the
@@ -865,6 +867,13 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			fes.AdminUpdateJumioBitClout,
 			SuperAdminAccess,
 		},
+		{
+			"AdminUpdateTutorialCreators",
+			[]string{"POST", "OPTIONS"},
+			RoutePathAdminUpdateTutorialCreators,
+			fes.AdminUpdateTutorialCreator,
+			SuperAdminAccess,
+		},
 		// End all /admin routes
 		// GET endpoints for managing parameters related to Buying BitClout
 		{
@@ -1095,7 +1104,7 @@ func AddHeaders(inner http.Handler, allowedOrigins []string) http.Handler {
 		if r.RequestURI == RoutePathUploadImage && strings.HasPrefix(contentType, "multipart/form-data") {
 			match = true
 			actualOrigin = "*"
-		} else if r.Method == "POST" && contentType != "application/json" && r.RequestURI != RoutePathJumioCallback{
+		} else if r.Method == "POST" && contentType != "application/json" && r.RequestURI != RoutePathJumioCallback {
 			invalidPostRequest = true
 		}
 

--- a/routes/shared.go
+++ b/routes/shared.go
@@ -5,6 +5,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -351,4 +352,11 @@ func (fes *APIServer) SendSeedBitClout(recipientPkBytes []byte, amountNanos uint
 		}
 	}
 	return hash, err
+}
+
+func ShuffleKeys(records *[][]byte) {
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(*records), func(i, j int) {
+		(*records)[i], (*records)[j] = (*records)[j], (*records)[i]
+	})
 }

--- a/routes/tutorial.go
+++ b/routes/tutorial.go
@@ -24,7 +24,7 @@ func (fes *APIServer) GetTutorialCreators(ww http.ResponseWriter, req *http.Requ
 	decoder := json.NewDecoder(io.LimitReader(req.Body, MaxRequestBodySizeBytes))
 	requestData := GetTutorialCreatorsRequest{}
 	if err := decoder.Decode(&requestData); err != nil {
-		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: Problem parsing request body: %v", err))
+		_AddBadRequestError(ww, fmt.Sprintf("GetTutorialCreators: Problem parsing request body: %v", err))
 		return
 	}
 	wellKnownSeekKey := _GlobalStateKeyWellKnownTutorialCreators
@@ -33,7 +33,7 @@ func (fes *APIServer) GetTutorialCreators(ww http.ResponseWriter, req *http.Requ
 	// Get a view
 	utxoView, err := fes.backendServer.GetMempool().GetAugmentedUniversalView()
 	if err != nil {
-		_AddBadRequestError(ww, fmt.Sprintf("GetSingleProfile: Error getting utxoView: %v", err))
+		_AddBadRequestError(ww, fmt.Sprintf("GetTutorialCreators: Error getting utxoView: %v", err))
 		return
 	}
 	upAndComingProfileEntryResponses, err := fes.GetFeaturedCreators(utxoView, requestData.ResponseLimit, upAndComingSeekKey)

--- a/routes/tutorial.go
+++ b/routes/tutorial.go
@@ -16,8 +16,8 @@ type GetTutorialCreatorsRequest struct {
 
 
 type GetTutorialCreatorResponse struct {
-	UpAndComingPublicKeysBase58Check []ProfileEntryResponse
-	WellKnownPublicKeysBase58Check []ProfileEntryResponse
+	UpAndComingProfileEntryResponses []ProfileEntryResponse
+	WellKnownProfileEntryResponses []ProfileEntryResponse
 }
 
 func (fes *APIServer) GetTutorialCreators(ww http.ResponseWriter, req *http.Request) {
@@ -50,8 +50,8 @@ func (fes *APIServer) GetTutorialCreators(ww http.ResponseWriter, req *http.Requ
 
 
 	res := GetTutorialCreatorResponse{
-		UpAndComingPublicKeysBase58Check: upAndComingProfileEntryResponses,
-		WellKnownPublicKeysBase58Check:   wellKnownProfileEntryResponses,
+		UpAndComingProfileEntryResponses: upAndComingProfileEntryResponses,
+		WellKnownProfileEntryResponses:   wellKnownProfileEntryResponses,
 	}
 	if err = json.NewEncoder(ww).Encode(res); err != nil {
 		_AddBadRequestError(ww, fmt.Sprintf("GetTutorialCreators: Problem encoding response as JSON: %v", err))

--- a/routes/tutorial.go
+++ b/routes/tutorial.go
@@ -1,0 +1,86 @@
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/bitclout/core/lib"
+	"github.com/btcsuite/btcd/btcec"
+	"io"
+	"net/http"
+)
+
+type GetTutorialCreatorsRequest struct {
+	ResponseLimit int
+	JWT       string
+}
+
+
+type GetTutorialCreatorResponse struct {
+	UpAndComingPublicKeysBase58Check []string
+	WellKnownPublicKeysBase58Check []string
+}
+
+func (fes *APIServer) GetTutorialCreators(ww http.ResponseWriter, req *http.Request) {
+	decoder := json.NewDecoder(io.LimitReader(req.Body, MaxRequestBodySizeBytes))
+	requestData := GetTutorialCreatorsRequest{}
+	if err := decoder.Decode(&requestData); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateTutorialCreator: Problem parsing request body: %v", err))
+		return
+	}
+	wellKnownSeekKey := _GlobalStateKeyWellKnownTutorialCreators
+	upAndComingSeekKey := _GlobalStateKeyUpAndComingTutorialCreators
+
+	upAndComingPublicKeysBase58Check, err := fes.GetFeaturedCreators(requestData.ResponseLimit, upAndComingSeekKey)
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("GetTutorialCreators: Problem getting up and coming tutorial creators: %v", err))
+		return
+	}
+	wellKnownPublicKeysBase58Check, err := fes.GetFeaturedCreators(requestData.ResponseLimit, wellKnownSeekKey)
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("GetTutorialCreators: Problem getting well known tutorial creators: %v", err))
+		return
+	}
+
+	res := GetTutorialCreatorResponse{
+		UpAndComingPublicKeysBase58Check: upAndComingPublicKeysBase58Check,
+		WellKnownPublicKeysBase58Check: wellKnownPublicKeysBase58Check,
+	}
+	if err = json.NewEncoder(ww).Encode(res); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("GetTutorialCreators: Problem encoding response as JSON: %v", err))
+		return
+	}
+}
+
+func (fes *APIServer) GetFeaturedCreators(responseLimit int, seekKey []byte) (_publicKeysBase58Check []string, _err error) {
+	maxKeyLen := 1 + btcec.PubKeyBytesLenCompressed
+	keys, _, err := fes.GlobalStateSeek(
+		seekKey,
+		seekKey,
+		maxKeyLen,
+		300,
+		true,
+		false,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("GetFeaturedCreators: Problem seeking through global state keys: #{err}")
+	}
+
+	var publicKeysUpperBound int
+	if len(keys) < responseLimit {
+		publicKeysUpperBound = len(keys)
+	} else {
+		publicKeysUpperBound = responseLimit
+	}
+
+	var publicKeysBase58Check []string
+	ShuffleKeys(&keys)
+	for _, dbKeyBytes := range keys[:publicKeysUpperBound] {
+		// Chop the public key out of the db key.
+		// The dbKeyBytes are: [One Prefix Byte][btcec.PubKeyBytesLenCompressed]
+		publicKeyBytes := dbKeyBytes[1 :][:]
+		publicKeyBase58Check := lib.Base58CheckEncode(publicKeyBytes, false, fes.Params)
+		publicKeysBase58Check = append(publicKeysBase58Check, publicKeyBase58Check)
+	}
+	return publicKeysBase58Check, nil
+}

--- a/routes/user.go
+++ b/routes/user.go
@@ -213,6 +213,10 @@ func (fes *APIServer) updateUserFieldsStateless(user *User, utxoView *lib.UtxoVi
 		user.JumioVerified = userMetadata.JumioVerified
 		user.JumioReturned = userMetadata.JumioReturned
 		user.JumioFinishedTime = userMetadata.JumioFinishedTime
+		if profileEntryy != nil {
+			user.ProfileEntryResponse.IsFeaturedTutorialUndiscoveredCreator = userMetadata.IsFeaturedTutorialUndiscoveredCreator
+			user.ProfileEntryResponse.IsFeaturedTutorialWellKnownCreator = userMetadata.IsFeaturedTutorialWellKnownCreator
+		}
 		if user.CanCreateProfile, err = fes.canUserCreateProfile(userMetadata, utxoView); err != nil {
 			return errors.Wrap(fmt.Errorf("updateUserFieldsStateless: Problem with canUserCreateProfile: %v", err), "")
 		}

--- a/routes/user.go
+++ b/routes/user.go
@@ -213,7 +213,7 @@ func (fes *APIServer) updateUserFieldsStateless(user *User, utxoView *lib.UtxoVi
 		user.JumioVerified = userMetadata.JumioVerified
 		user.JumioReturned = userMetadata.JumioReturned
 		user.JumioFinishedTime = userMetadata.JumioFinishedTime
-    user.TutorialStatus = userMetadata.TutorialStatus
+		user.TutorialStatus = userMetadata.TutorialStatus
 		// We only need to fetch the creator purchased in the tutorial if the user is still in the tutorial
 		if user.TutorialStatus != COMPLETE && user.TutorialStatus != SKIPPED && userMetadata.CreatorPurchasedInTutorialPKID != nil {
 			profileEntry := utxoView.GetProfileEntryForPKID(userMetadata.CreatorPurchasedInTutorialPKID)
@@ -223,10 +223,10 @@ func (fes *APIServer) updateUserFieldsStateless(user *User, utxoView *lib.UtxoVi
 			username := string(profileEntry.Username)
 			user.CreatorPurchasedInTutorialUsername = &username
 		}
-    if profileEntryy != nil {
+		if profileEntryy != nil {
 			user.ProfileEntryResponse.IsFeaturedTutorialUpAndComingCreator = userMetadata.IsFeaturedTutorialUpAndComingCreator
 			user.ProfileEntryResponse.IsFeaturedTutorialWellKnownCreator = userMetadata.IsFeaturedTutorialWellKnownCreator
-    }
+		}
 		if user.CanCreateProfile, err = fes.canUserCreateProfile(userMetadata, utxoView); err != nil {
 			return errors.Wrap(fmt.Errorf("updateUserFieldsStateless: Problem with canUserCreateProfile: %v", err), "")
 		}
@@ -260,8 +260,6 @@ func (fes *APIServer) updateUserFieldsStateless(user *User, utxoView *lib.UtxoVi
 	user.IsAdmin = isAdmin
 	user.IsSuperAdmin = isSuperAdmin
 
-	// We expect SeedInfo and LocalState are set and don't mess with them in this
-	// function.
 
 	return nil
 }
@@ -1105,9 +1103,7 @@ func (fes *APIServer) GetSingleProfile(ww http.ResponseWriter, req *http.Request
 		res.IsGraylisted = true
 	}
 
-	isAdmin, _ := fes.UserAdminStatus(publicKeyBase58Check)
-
-	if isAdmin {
+	if isAdmin, _ := fes.UserAdminStatus(publicKeyBase58Check); isAdmin {
 		var userMetadata *UserMetadata
 		userMetadata, err = fes.getUserMetadataFromGlobalState(publicKeyBase58Check)
 		if err != nil {


### PR DESCRIPTION
Create 2 new routes, `get-tutorial-creators` and `update-tutorial-creators`, to enable featured tutorial creators to be managed. Also update `GetSingleProfile` and `GetUsersStateless` routes to include user metadata fields indicating whether a creator is featured.