### PR TITLE
Remove hardcoded base58 key prefixes and compute based on params

### DIFF
--- a/routes/admin_transaction.go
+++ b/routes/admin_transaction.go
@@ -214,7 +214,7 @@ type SwapIdentityResponse struct {
 }
 
 func (fes *APIServer) getPublicKeyFromUsernameOrPublicKeyString(usernameOrPublicKey string) ([]byte, error) {
-	if (strings.HasPrefix(usernameOrPublicKey, "BC") || strings.HasPrefix(usernameOrPublicKey, "tBC")) &&
+	if (strings.HasPrefix(usernameOrPublicKey, fes.PublicKeyBase58Prefix)) &&
 		len(usernameOrPublicKey) >= btcec.PubKeyBytesLenCompressed {
 
 		// In this case parse the string as a public key.

--- a/routes/server.go
+++ b/routes/server.go
@@ -218,6 +218,10 @@ type APIServer struct {
 	LastTradeBitCloutPriceHistory []LastTradePriceHistoryItem
 	// How far back do we consider trade prices when we set the current price of $CLOUT in nanoseconds
 	LastTradePriceLookback uint64
+
+	// Base-58 prefix to check for to determine if a string could be a public key.
+	PublicKeyBase58Prefix string
+
 	// Signals that the frontend server is in a stopped state
 	quit chan struct{}
 }
@@ -247,6 +251,8 @@ func NewAPIServer(
 			"NewAPIServer: Error: A globalStateDB or a globalStateRemoteNode is required")
 	}
 
+	publicKeyBase58Prefix := lib.Base58CheckEncode(make([]byte, btcec.PubKeyBytesLenCompressed), false, params)[0:3]
+
 	fes := &APIServer{
 		// TODO: It would be great if we could eliminate the dependency on
 		// the backendServer. Right now it's here because it was the easiest
@@ -263,6 +269,7 @@ func NewAPIServer(
 		Twilio:                        twilio,
 		BlockCypherAPIKey:             blockCypherAPIKey,
 		LastTradeBitCloutPriceHistory: []LastTradePriceHistoryItem{},
+		PublicKeyBase58Prefix:         publicKeyBase58Prefix,
 		// We consider last trade prices from the last hour when determining the current price of BitClout.
 		// This helps prevents attacks that attempt to purchase $CLOUT at below market value.
 		LastTradePriceLookback: uint64(time.Hour.Nanoseconds()),

--- a/routes/transaction.go
+++ b/routes/transaction.go
@@ -320,10 +320,9 @@ func (fes *APIServer) UpdateProfile(ww http.ResponseWriter, req *http.Request) {
 		profilePublicKey = profilePublicKeyBytess
 	}
 
-	if len(requestData.NewUsername) > 0 && (strings.Index(requestData.NewUsername, "BC") == 0 ||
-		strings.Index(requestData.NewUsername, "tBC") == 0) {
+	if len(requestData.NewUsername) > 0 && strings.Index(requestData.NewUsername, fes.PublicKeyBase58Prefix) == 0 {
 		_AddBadRequestError(ww, fmt.Sprintf(
-			"UpdateProfile: Username cannot start with BC or tBC"))
+			"UpdateProfile: Username cannot start with %s", fes.PublicKeyBase58Prefix))
 		return
 	}
 
@@ -907,8 +906,7 @@ func (fes *APIServer) SendBitClout(ww http.ResponseWriter, req *http.Request) {
 	// a public key. Otherwise we interpret it as a username and try to look up
 	// the corresponding profile.
 	var recipientPkBytes []byte
-	if strings.Index(requestData.RecipientPublicKeyOrUsername, "BC") == 0 ||
-		strings.Index(requestData.RecipientPublicKeyOrUsername, "tBC") == 0 {
+	if strings.Index(requestData.RecipientPublicKeyOrUsername, fes.PublicKeyBase58Prefix) == 0 {
 
 		// Decode the recipient's public key.
 		var err error
@@ -1189,8 +1187,7 @@ func (fes *APIServer) SubmitPost(ww http.ResponseWriter, req *http.Request) {
 					requestData.ParentStakeID, err))
 				return
 			}
-		} else if strings.Index(requestData.ParentStakeID, "BC") == 0 ||
-			strings.Index(requestData.ParentStakeID, "tBC") == 0 {
+		} else if strings.Index(requestData.ParentStakeID, fes.PublicKeyBase58Prefix) == 0 {
 
 			parentStakeID, _, err = lib.Base58CheckDecode(requestData.ParentStakeID)
 			if err != nil || len(parentStakeID) != btcec.PubKeyBytesLenCompressed {


### PR DESCRIPTION
Several places in `backend` hardcoded the public key base 58 prefix `BC` and `tBC`. This PR updates the code to compute this prefix dynamically based on `Params`, which can be useful if the prefix has been adjusted (for example, in a private testnet.)